### PR TITLE
updated to more idiomatic instructions

### DIFF
--- a/golang/README.md
+++ b/golang/README.md
@@ -12,15 +12,15 @@
 
 <pre>
 cd $MY_SRC_HOME
-docker run -i -t -v $MY_SRC_HOME:/data golang
-cd /data
+docker run --rm -it -v $(pwd):/go golang
+cd /go/src/life
 </pre>
 
 ## To run tests
 
-* `go test life`
+* `go test`
 
 ## To run main program
 
-* `go install life`
-* `./bin/life`
+* `go install`
+* `life`


### PR DESCRIPTION
- added `--rm` to docker command to remove the container when it exists. this way you aren't left with a bunch of dangling containers from running it a bunch of times
- mount the `src` directory in `$GOPATH/src` - go uses `$GOPATH` to store all of your code (https://golang.org/doc/code.html#GOPATH) and in this image it is set to `/go`
- once the code is in `$GOPATH` you can just run `go test` and `go install` in the project directory. `go install` will install to `$GOPATH/bin` which is already in `$PATH` so you can just run `life` system wide.
