### PR TITLE
Change js testing

### DIFF
--- a/javascript/README.md
+++ b/javascript/README.md
@@ -2,9 +2,10 @@
 ## Requirements
 
 * install [Node JS](https://nodejs.org/en/download/)
-* install karma
-    * `npm install karma --save-dev`
+* run `npm install`
 
 ## To run tests
 
-* `karma start karma.config.js`
+* `npm run test`
+
+Running the tests will continuously monitor for file changes and re-run all tests when that occurs.

--- a/javascript/karma.config.js
+++ b/javascript/karma.config.js
@@ -57,7 +57,7 @@ module.exports = function(config) {
     // - Safari (only Mac; has to be installed with `npm install karma-safari-launcher`)
     // - PhantomJS
     // - IE (only Windows; has to be installed with `npm install karma-ie-launcher`)
-    browsers: ['Chrome'],
+    browsers: ['PhantomJS'],
 
     // If browser does not capture in given timeout [ms], kill it
     captureTimeout: 60000,

--- a/javascript/model/cell.js
+++ b/javascript/model/cell.js
@@ -1,8 +1,7 @@
 
 // http://peidevs.github.io
 
-class Cell {
-    constructor(options) {
-        this.foo = options.foo;
-    }
-}
+var Cell = function(options) {
+    this.foo = options.foo;
+};
+

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "gdcr-js-scaffolding",
+  "version": "1.0.0",
+  "description": "JavaScript Scaffolding for GDCR",
+  "main": "karma.config.js",
+  "directories": {
+    "test": "tests"
+  },
+  "dependencies": {
+    "karma": "^1.3.0"
+  },
+  "devDependencies": {
+    "jasmine": "^2.5.2",
+    "karma": "^1.3.0",
+    "karma-jasmine": "^1.0.2",
+    "karma-phantomjs-launcher": "^1.0.2"
+  },
+  "scripts": {
+    "test": "karma start karma.config.js"
+  },
+  "author": "Michael Easter",
+  "license": "ISC"
+}

--- a/javascript/tests/canaryTest.js
+++ b/javascript/tests/canaryTest.js
@@ -1,14 +1,14 @@
 
 // http://peidevs.github.io 
 
-describe("Canary Test", () => {
+describe("Canary Test", function() {
     var cell
  
-    beforeEach( () => {
+    beforeEach( function() {
         cell = new Cell({foo: 5150})
     })
  
-    it("can be alive", () => {
+    it("can be alive", function() {
         expect(cell.foo).toEqual(5150)
     })
 });


### PR DESCRIPTION
This will allow karma to run much easier. 

A change from previous behaviour is that the test process will not exit, but continually monitor source and tests files for changes, and then re-run the changes if that happens. `CTRL-C` exits the test process.

Having the `karma.config.js` file point to "Chrome" would actually open Chrome on my Mac, and that's the only reason I switched to PhantomJS.

Not sure if this breaks Travis CI.
