### PR TITLE
Update PHP version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.0'
           extensions: curl, libxml, mbstring
           coverage: none
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: get code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: cache dependencies (Gradle)
         id: cache
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: get code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: run unit tests
         working-directory: c
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: get code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install clojure tools
         uses: DeLaGuardo/setup-clojure@10.0
@@ -76,7 +76,7 @@ jobs:
 #
 #    steps:
 #      - name: get code
-#        uses: actions/checkout@v3
+#        uses: actions/checkout@v4
 #
 #      - name: install NUnit
 #        run: |
@@ -100,7 +100,7 @@ jobs:
 
     steps:
       - name: get code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: get Go
         uses: actions/setup-go@v3
@@ -119,7 +119,7 @@ jobs:
 
     steps:
       - name: get code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: cache dependencies (Gradle)
         uses: actions/cache@v3
@@ -147,7 +147,7 @@ jobs:
 
     steps:
       - name: get code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: cache dependencies (Gradle)
         uses: actions/cache@v3
@@ -174,7 +174,7 @@ jobs:
 #
 #    steps:
 #      - name: get code
-#        uses: actions/checkout@v3
+#        uses: actions/checkout@v4
 #
 #      - name: install
 #        run: npm install
@@ -190,7 +190,7 @@ jobs:
 
     steps:
       - name: get code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: cache dependencies (Gradle)
         uses: actions/cache@v3
@@ -217,7 +217,7 @@ jobs:
 
     steps:
       - name: get code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -239,7 +239,7 @@ jobs:
 
     steps:
       - name: get code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: run unit tests
         working-directory: python
@@ -250,7 +250,7 @@ jobs:
 
     steps:
       - name: get code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: run unit tests
         working-directory: ruby
@@ -262,7 +262,7 @@ jobs:
 
     steps:
       - name: get code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: cache dependencies (Gradle)
         uses: actions/cache@v3
@@ -291,7 +291,7 @@ jobs:
 #
 #    steps:
 #      - name: get code
-#        uses: actions/checkout@v3
+#        uses: actions/checkout@v4
 #
 #      - name: run unit tests
 #        run: ./test.sh
@@ -302,10 +302,10 @@ jobs:
 
     steps:
       - name: get code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node.js 18.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '18.x'
 

--- a/php/README.md
+++ b/php/README.md
@@ -2,7 +2,7 @@
 ## Requirements
 
 * install [PHP](https://www.php.net/manual/en/install.php)
-    - PHP 7.4+
+    - PHP 8.0+
 * install [composer](https://getcomposer.org/doc/00-intro.md#installation-linux-unix-macos)
 
 ## To run tests

--- a/php/composer.json
+++ b/php/composer.json
@@ -7,7 +7,7 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0"
+        "php": "^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.1|^10.0"

--- a/php/composer.json
+++ b/php/composer.json
@@ -10,7 +10,7 @@
         "php": "^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.1|^10.0"
+        "phpunit/phpunit": "^9.1|^10.0|^11.0"
     },
     "autoload": {
         "classmap": ["src"]


### PR DESCRIPTION
This PR drops the 7.4 PHP version and make 8.0 the minimum supported version.
In addition, it adds a new version of PHPUnit testing framework and bumps some action versions in the ci.yml file.

*Note* it update ci.yml in the same way as #7 and it shouldn't conflict with it.